### PR TITLE
Consider merge conflict only in dirty status

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,7 +26,7 @@ jobs:
         with:
           conflict_label_name: "has conflict"
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          detect_merge_changes: true
+          mergeable_only: true
 
   coverage:
     needs: [build, e2e]

--- a/README.md
+++ b/README.md
@@ -32,14 +32,14 @@ jobs:
   auto-label:
     runs-on: ubuntu-latest
     steps:
-      - uses: prince-chrismc/label-merge-conflicts-action@v1
+      - uses: prince-chrismc/label-merge-conflicts-action@v1 # Replace this with the latest version
         with:
           conflict_label_name: "has conflict"
           github_token: ${{ secrets.GITHUB_TOKEN }}
           # These are optional incase you need to adjust for the limitations described below
           max_retries: 5
           wait_ms: 15000
-          detect_merge_changes: false # or true to handle as conflicts
+          mergeable_only: false # or true to unlabel as soon as all the merge requirements are fulfilled
 ```
 
 ## Limitations
@@ -54,7 +54,16 @@ jobs:
 
 ## FAQ - What are _Merge Changes_?
 
-During a merge, no matter the [strategy](https://git-scm.com/docs/merge-strategies), there may inadvertently be changes which can have negative side effects. For example, it may result in code that is no longer syntactically correct or checksums to be out of date.
+By default, as soon as the conflicts are resolved, the action will remove the assigned label. However, you can do it after requirements, like CI checks
+and reviews in protected branches are succesful. For this to work correctly, you must replace the events:
+
+```yml
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+```
 
 ## FAQ - How do I fix _"Resource not accessible by integration"_?
 

--- a/__tests__/main.test.ts
+++ b/__tests__/main.test.ts
@@ -3,18 +3,16 @@ import * as github from '@actions/github'
 import nock from 'nock'
 
 import {wait} from '../src/wait'
-import {IGitHubRepoLabels, IGitHubPRNode, IGitHubLabelNode, IGitHubPullRequest} from '../src/interfaces'
+import {IGitHubRepoLabels, IGitHubPRNode, IGitHubLabelNode, IGitHubPullRequest, MergeableState, MergeStateStatus} from '../src/interfaces'
 import {findLabelByName, isAlreadyLabeled} from '../src/util'
 import {
   getLabels,
   getPullRequests,
   addLabelToLabelable,
   removeLabelFromLabelable,
-  getPullRequestChanges,
-  getCommitChanges,
   getPullRequest
 } from '../src/queries'
-import {checkPullRequestForMergeChanges, gatherPullRequests, gatherPullRequest} from '../src/pulls'
+import {gatherPullRequests, gatherPullRequest} from '../src/pulls'
 import {updatePullRequestConflictLabel} from '../src/label'
 import {run} from '../src/run'
 
@@ -71,10 +69,8 @@ describe('pr label checking', () => {
     return {
       id: 'MDExOlB1bGxSZXF1ZXN0NTc4ODgyNDUw',
       number: 7,
-      mergeable: 'MERGEABLE',
-      potentialMergeCommit: {
-        oid: '5ed0e15d4ca4ce73e847ee1f0369ee85a6e67bc9'
-      },
+      mergeable: MergeableState.MERGEABLE,
+      mergeStateStatus: MergeStateStatus.CLEAN,
       labels: {edges: [...label]}
     }
   }
@@ -332,7 +328,8 @@ describe('queries', () => {
                     node: {
                       id: 'MDExOlB1bGxSZXF1ZXN0NTc4ODgyNDUw',
                       number: 7,
-                      mergeable: 'MERGEABLE',
+                      mergeable: MergeableState.MERGEABLE,
+                      mergeStateStatus: MergeStateStatus.CLEAN,
                       labels: {edges: []}
                     }
                   }
@@ -349,7 +346,7 @@ describe('queries', () => {
       expect(pullRequests.length).toBe(1)
       expect(pullRequests[0].node.id).toBe('MDExOlB1bGxSZXF1ZXN0NTc4ODgyNDUw')
       expect(pullRequests[0].node.number).toBe(7)
-      expect(pullRequests[0].node.mergeable).toBe('MERGEABLE')
+      expect(pullRequests[0].node.mergeable).toBe(MergeableState.MERGEABLE)
       expect(pullRequests[0].node.labels.edges.length).toBe(0)
     })
 
@@ -366,10 +363,8 @@ describe('queries', () => {
               pullRequest: {
                 id: 'MDExOlB1bGxSZXF1ZXN0NTk3NDgzNjg4',
                 number: 49,
-                mergeable: 'MERGEABLE',
-                potentialMergeCommit: {
-                  oid: '8b0ec723ab52932bf3476b711df72f762742bede'
-                },
+                mergeable: MergeableState.MERGEABLE,
+                mergeStateStatus: MergeStateStatus.CLEAN,
                 labels: {
                   edges: [
                     {
@@ -390,7 +385,7 @@ describe('queries', () => {
 
       expect(pullRequests.id).toBe('MDExOlB1bGxSZXF1ZXN0NTk3NDgzNjg4')
       expect(pullRequests.number).toBe(49)
-      expect(pullRequests.mergeable).toBe('MERGEABLE')
+      expect(pullRequests.mergeable).toBe(MergeableState.MERGEABLE)
       expect(pullRequests.labels.edges.length).toBe(1)
     })
 
@@ -410,7 +405,8 @@ describe('queries', () => {
                     node: {
                       id: 'MDExOlB1bGxSZXF1ZXN0NTc4ODgyNDUw',
                       number: 7,
-                      mergeable: 'MERGEABLE',
+                      mergeable: MergeableState.MERGEABLE,
+                      mergeStateStatus: MergeStateStatus.CLEAN,
                       labels: {edges: []}
                     }
                   }
@@ -430,7 +426,8 @@ describe('queries', () => {
                     node: {
                       id: 'justsomestring',
                       number: 64,
-                      mergeable: 'MERGEABLE',
+                      mergeable: MergeableState.MERGEABLE,
+                      mergeStateStatus: MergeStateStatus.CLEAN,
                       labels: {edges: []}
                     }
                   }
@@ -447,12 +444,12 @@ describe('queries', () => {
       expect(pullRequests.length).toBe(2)
       expect(pullRequests[0].node.id).toBe('MDExOlB1bGxSZXF1ZXN0NTc4ODgyNDUw')
       expect(pullRequests[0].node.number).toBe(7)
-      expect(pullRequests[0].node.mergeable).toBe('MERGEABLE')
+      expect(pullRequests[0].node.mergeable).toBe(MergeableState.MERGEABLE)
       expect(pullRequests[0].node.labels.edges.length).toBe(0)
 
       expect(pullRequests[1].node.id).toBe('justsomestring')
       expect(pullRequests[1].node.number).toBe(64)
-      expect(pullRequests[1].node.mergeable).toBe('MERGEABLE')
+      expect(pullRequests[1].node.mergeable).toBe(MergeableState.MERGEABLE)
       expect(pullRequests[1].node.labels.edges.length).toBe(0)
     })
 
@@ -472,7 +469,8 @@ describe('queries', () => {
                     node: {
                       id: 'MDExOlB1bGxSZXF1ZXN0NTc4ODgyNDUw',
                       number: 7,
-                      mergeable: 'UNKNOWN',
+                      mergeable: MergeableState.UNKNOWN,
+                      mergeStateStatus: MergeStateStatus.UNKNOWN,
                       labels: {edges: []}
                     }
                   },
@@ -480,7 +478,8 @@ describe('queries', () => {
                     node: {
                       id: 'justsomestring',
                       number: 64,
-                      mergeable: 'MERGEABLE',
+                      mergeable: MergeableState.MERGEABLE,
+                      mergeStateStatus: MergeStateStatus.CLEAN,
                       labels: {edges: []}
                     }
                   }
@@ -500,7 +499,8 @@ describe('queries', () => {
                     node: {
                       id: 'MDExOlB1bGxSZXF1ZXN0NTc4ODgyNDUw',
                       number: 7,
-                      mergeable: 'MERGEABLE',
+                      mergeable: MergeableState.MERGEABLE,
+                      mergeStateStatus: MergeStateStatus.CLEAN,
                       labels: {edges: []}
                     }
                   },
@@ -508,7 +508,8 @@ describe('queries', () => {
                     node: {
                       id: 'justsomestring',
                       number: 64,
-                      mergeable: 'MERGEABLE',
+                      mergeable: MergeableState.MERGEABLE,
+                      mergeStateStatus: MergeStateStatus.CLEAN,
                       labels: {edges: []}
                     }
                   }
@@ -525,12 +526,12 @@ describe('queries', () => {
       expect(pullRequests.length).toBe(2)
       expect(pullRequests[0].node.id).toBe('MDExOlB1bGxSZXF1ZXN0NTc4ODgyNDUw')
       expect(pullRequests[0].node.number).toBe(7)
-      expect(pullRequests[0].node.mergeable).toBe('MERGEABLE')
+      expect(pullRequests[0].node.mergeable).toBe(MergeableState.MERGEABLE)
       expect(pullRequests[0].node.labels.edges.length).toBe(0)
 
       expect(pullRequests[1].node.id).toBe('justsomestring')
       expect(pullRequests[1].node.number).toBe(64)
-      expect(pullRequests[1].node.mergeable).toBe('MERGEABLE')
+      expect(pullRequests[1].node.mergeable).toBe(MergeableState.MERGEABLE)
       expect(pullRequests[1].node.labels.edges.length).toBe(0)
     })
   })
@@ -552,7 +553,8 @@ describe('queries', () => {
                   node: {
                     id: 'MDExOlB1bGxSZXF1ZXN0NTc4ODgyNDUw',
                     number: 7,
-                    mergeable: 'UNKNOWN',
+                    mergeable: MergeableState.UNKNOWN,
+                    mergeStateStatus: MergeStateStatus.UNKNOWN,
                     labels: {edges: []}
                   }
                 },
@@ -560,7 +562,8 @@ describe('queries', () => {
                   node: {
                     id: 'justsomestring',
                     number: 64,
-                    mergeable: 'MERGEABLE',
+                    mergeable: MergeableState.MERGEABLE,
+                    mergeStateStatus: MergeStateStatus.CLEAN,
                     labels: {edges: []}
                   }
                 }
@@ -581,12 +584,12 @@ describe('queries', () => {
     expect(pullRequests.length).toBe(2)
     expect(pullRequests[0].node.id).toBe('MDExOlB1bGxSZXF1ZXN0NTc4ODgyNDUw')
     expect(pullRequests[0].node.number).toBe(7)
-    expect(pullRequests[0].node.mergeable).toBe('UNKNOWN')
+    expect(pullRequests[0].node.mergeable).toBe(MergeableState.UNKNOWN)
     expect(pullRequests[0].node.labels.edges.length).toBe(0)
 
     expect(pullRequests[1].node.id).toBe('justsomestring')
     expect(pullRequests[1].node.number).toBe(64)
-    expect(pullRequests[1].node.mergeable).toBe('MERGEABLE')
+    expect(pullRequests[1].node.mergeable).toBe(MergeableState.MERGEABLE)
     expect(pullRequests[1].node.labels.edges.length).toBe(0)
   })
 
@@ -603,10 +606,8 @@ describe('queries', () => {
             pullRequest: {
               id: 'MDExOlB1bGxSZXF1ZXN0NTk3NDgzNjg4',
               number: mockPullRequestEvent.number,
-              mergeable: 'UNKNOWN',
-              potentialMergeCommit: {
-                oid: '8b0ec723ab52932bf3476b711df72f762742bede'
-              },
+              mergeable: MergeableState.UNKNOWN,
+              mergeStateStatus: MergeStateStatus.UNKNOWN,
               labels: {
                 edges: [
                   {
@@ -628,10 +629,8 @@ describe('queries', () => {
             pullRequest: {
               id: 'MDExOlB1bGxSZXF1ZXN0NTk3NDgzNjg4',
               number: mockPullRequestEvent.number,
-              mergeable: 'MERGEABLE',
-              potentialMergeCommit: {
-                oid: '8b0ec723ab52932bf3476b711df72f762742bede'
-              },
+              mergeable: MergeableState.MERGEABLE,
+              mergeStateStatus: MergeStateStatus.CLEAN,
               labels: {
                 edges: [
                   {
@@ -658,7 +657,7 @@ describe('queries', () => {
 
     expect(pullRequest.id).toBe('MDExOlB1bGxSZXF1ZXN0NTk3NDgzNjg4')
     expect(pullRequest.number).toBe(mockPullRequestEvent.number)
-    expect(pullRequest.mergeable).toBe('MERGEABLE')
+    expect(pullRequest.mergeable).toBe(MergeableState.MERGEABLE)
     expect(pullRequest.labels.edges.length).toBe(1)
   })
 
@@ -676,10 +675,8 @@ describe('queries', () => {
             pullRequest: {
               id: 'MDExOlB1bGxSZXF1ZXN0NTk3NDgzNjg4',
               number: mockPullRequestEvent.number,
-              mergeable: 'UNKNOWN',
-              potentialMergeCommit: {
-                oid: '8b0ec723ab52932bf3476b711df72f762742bede'
-              },
+              mergeable: MergeableState.UNKNOWN,
+              mergeStateStatus: MergeStateStatus.UNKNOWN,
               labels: {
                 edges: [
                   {
@@ -791,316 +788,14 @@ describe('queries', () => {
     })
   })
 
-  describe('gathers files changed', () => {
-    describe('pull request', () => {
-      it('gets a list', async () => {
-        const scope = nock('https://api.github.com', {
-          reqheaders: {
-            authorization: 'token justafaketoken'
-          }
-        })
-          .get(`/repos/${github.context.repo.owner}/${github.context.repo.repo}/pulls/123/files?per_page=300`)
-          .reply(200, [
-            {
-              sha: 'a8f3b51f97dbe31d1da584262e01b3ac2465d2d8',
-              filename: 'recipes/protobuf/all/conandata.yml',
-              patch:
-                '@@ -20,6 +20,17 @@ patches:\n       base_path: "source_subfolder"\n     - patch_file: "patches/upstream-issue-7567-no-exp...'
-            },
-            {
-              sha: 'cb0f93f2eeaa80d2fbddff1d7169e254f89b7ecb',
-              filename: 'recipes/protobuf/all/conanfile.py',
-              status: 'modified',
-              patch:
-                '@@ -109,7 +109,7 @@ def _patch_sources(self):\n         find_protoc = """\n \n # Find the protobuf compiler within t...'
-            }
-          ])
-
-        const octokit = github.getOctokit('justafaketoken')
-        const prChanges = await getPullRequestChanges(octokit, github.context, 123)
-
-        expect(prChanges).toBeTruthy()
-        expect(prChanges.length).toBe(2)
-        expect(prChanges[1].sha).toBe('cb0f93f2eeaa80d2fbddff1d7169e254f89b7ecb')
-        expect(prChanges[1].filename).toBe('recipes/protobuf/all/conanfile.py')
-      })
-
-      it('throws on error response', async () => {
-        const scope = nock('https://api.github.com', {
-          reqheaders: {
-            authorization: 'token justafaketoken'
-          }
-        })
-          .get(`/repos/${github.context.repo.owner}/${github.context.repo.repo}/pulls/123/files?per_page=300`)
-          .reply(404, {
-            message: 'Not Found',
-            documentation_url: 'https://docs.github.com/rest/reference/pulls#list-pull-requests-files'
-          })
-
-        const octokit = github.getOctokit('justafaketoken')
-        const prCahnges = getPullRequestChanges(octokit, github.context, 123)
-
-        await expect(prCahnges).rejects.toThrowError(/Not Found/)
-      })
-    })
-
-    describe('merge commit', () => {
-      const changes = [
-        {
-          sha: '06ea1fc2136e77e11f43923bd4c446fc8ea5caa3',
-          filename: 'recipes/graphene/all/conandata.yml',
-          status: 'added',
-          patch:
-            '@@ -0,0 +1,4 @@\n+sources:\n+  "1.10.2":\n+    url: "https://github.com/ebassi/graphene/releases/download/1.10.2/graphene-1.10.2...'
-        },
-        {
-          sha: '8d9cd557cf27237c1ccc3cd4cf77a3033212d350',
-          filename: 'recipes/graphene/all/conanfile.py',
-          status: 'added',
-          patch:
-            '@@ -0,0 +1,96 @@\n+from conans import ConanFile, Meson, tools\n+from conans.errors import ConanInvalidConfiguration\n+import os\n+\n+req...'
-        },
-        {
-          sha: 'f21465c9d35d01b9d27d822dc0efe05f39f1f792',
-          filename: 'recipes/graphene/config.yml',
-          status: 'added',
-          patch: '@@ -0,0 +1,3 @@\n+versions:\n+    "1.10.2":\n+        folder: "all"'
-        }
-      ]
-      it('gets a list', async () => {
-        const scope = nock('https://api.github.com', {
-          reqheaders: {
-            authorization: 'token justafaketoken'
-          }
-        })
-          .get(`/repos/${github.context.repo.owner}/${github.context.repo.repo}/commits/${github.context.sha}`)
-          .reply(200, {
-            sha: '78db84765bc6de1a254d969c4d6b2f09a9862355',
-            node_id: 'MDY6Q29tbWl0MjA0NjcxMjMyOjc4ZGI4NDc2NWJjNmRlMWEyNTRkOTY5YzRkNmIyZjA5YTk4NjIzNTU=',
-            commit: {
-              author: {
-                date: '2021-01-07T15:31:36Z'
-              },
-              committer: {
-                name: 'GitHub',
-                email: 'noreply@github.com',
-                date: '2021-01-07T15:31:36Z'
-              },
-              message: 'Generic PR'
-            },
-            committer: {
-              login: 'web-flow',
-              id: 19864447,
-              node_id: 'MDQ6VXNlcjE5ODY0NDQ3'
-            },
-            parents: [
-              {
-                sha: 'b90be7f65a6eb23aa2c402d27d10ef548ac4be4e'
-              }
-            ],
-            files: changes
-          })
-
-        const octokit = github.getOctokit('justafaketoken')
-        const mergeChanges = await getCommitChanges(octokit, github.context, github.context.sha)
-
-        expect(mergeChanges).toBeTruthy()
-        expect(mergeChanges.length).toBe(3)
-        expect(mergeChanges[2].sha).toBe('f21465c9d35d01b9d27d822dc0efe05f39f1f792')
-        expect(mergeChanges[2].filename).toBe('recipes/graphene/config.yml')
-      })
-
-      it('throws on error response', async () => {
-        const scope = nock('https://api.github.com', {
-          reqheaders: {
-            authorization: 'token justafaketoken'
-          }
-        })
-          .get(`/repos/${github.context.repo.owner}/${github.context.repo.repo}/commits/${github.context.sha}`)
-          .reply(422, {
-            message: 'No commit found for SHA: 78db84765bc6de1a254d969c4d6b2f09a62355',
-            documentation_url: 'https://docs.github.com/rest/reference/repos#get-a-commit'
-          })
-
-        const octokit = github.getOctokit('justafaketoken')
-
-        const mergeChanges = getCommitChanges(octokit, github.context, github.context.sha)
-        expect(mergeChanges).rejects.toThrowError(/No commit found/)
-      })
-
-      it('throws with no files', async () => {
-        const scope = nock('https://api.github.com', {
-          reqheaders: {
-            authorization: 'token justafaketoken'
-          }
-        })
-          .get(`/repos/${github.context.repo.owner}/${github.context.repo.repo}/commits/${github.context.sha}`)
-          .reply(200, {
-            sha: '78db84765bc6de1a254d969c4d6b2f09a9862355',
-            node_id: 'MDY6Q29tbWl0MjA0NjcxMjMyOjc4ZGI4NDc2NWJjNmRlMWEyNTRkOTY5YzRkNmIyZjA5YTk4NjIzNTU=',
-            commit: {
-              author: {
-                date: '2021-01-07T15:31:36Z'
-              },
-              committer: {
-                name: 'GitHub',
-                email: 'noreply@github.com',
-                date: '2021-01-07T15:31:36Z'
-              },
-              message: 'Some Pull Request'
-            },
-            committer: {
-              login: 'web-flow',
-              id: 19864447,
-              node_id: 'MDQ6VXNlcjE5ODY0NDQ3'
-            },
-            parents: [
-              {
-                sha: 'b90be7f65a6eb23aa2c402d27d10ef548ac4be4e'
-              }
-            ]
-          })
-
-        const octokit = github.getOctokit('justafaketoken')
-
-        const mergeChanges = getCommitChanges(octokit, github.context, github.context.sha)
-        expect(mergeChanges).rejects.toThrowError(/unknown diff/)
-      })
-    })
-
-    describe('determines changes', () => {
-      const prNode: IGitHubPRNode = {
-        node: {
-          id: 'MDExOlB1bGxSZXF1ZXN0NTc4ODgyNDUw',
-          number: 7,
-          mergeable: 'MERGEABLE',
-          potentialMergeCommit: {
-            oid: '5ed0e15d4ca4ce73e847ee1f0369ee85a6e67bc9'
-          },
-          labels: {edges: []}
-        }
-      }
-
-      const changes = [
-        {
-          sha: 'a8f3b51f97dbe31d1da584262e01b3ac2465d2d8',
-          filename: 'recipes/protobuf/all/conandata.yml',
-          patch:
-            '@@ -20,6 +20,17 @@ patches:\n       base_path: "source_subfolder"\n     - patch_file: "patches/upstream-issue-7567-no-exp...'
-        },
-        {
-          sha: 'cb0f93f2eeaa80d2fbddff1d7169e254f89b7ecb',
-          filename: 'recipes/protobuf/all/conanfile.py',
-          status: 'modified',
-          patch:
-            '@@ -109,7 +109,7 @@ def _patch_sources(self):\n         find_protoc = """\n \n # Find the protobuf compiler within t...'
-        }
-      ]
-
-      const makeCommitPage = (...changes: any[]) => {
-        return {
-          sha: '5ed0e15d4ca4ce73e847ee1f0369ee85a6e67bc9',
-          node_id: 'MDY6Q29tbWl0MjA0NjcxMjMyOjc4ZGI4NDc2NWJjNmRlMWEyNTRkOTY5YzRkNmIyZjA5YTk4NjIzNTU=',
-          commit: {
-            author: {
-              date: '2021-01-07T15:31:36Z'
-            },
-            committer: {
-              name: 'GitHub',
-              email: 'noreply@github.com',
-              date: '2021-01-07T15:31:36Z'
-            },
-            message: 'Generic PR'
-          },
-          committer: {
-            login: 'web-flow',
-            id: 19864447,
-            node_id: 'MDQ6VXNlcjE5ODY0NDQ3'
-          },
-          parents: [
-            {
-              sha: 'b90be7f65a6eb23aa2c402d27d10ef548ac4be4e'
-            }
-          ],
-          files: [...changes]
-        }
-      }
-
-      it('returns yes when list size is different', async () => {
-        const scope = nock('https://api.github.com', {
-          reqheaders: {
-            authorization: 'token justafaketoken'
-          }
-        })
-          .get(
-            `/repos/${github.context.repo.owner}/${github.context.repo.repo}/pulls/${prNode.node.number}/files?per_page=300`
-          )
-          .reply(200, changes)
-          .get(
-            `/repos/${github.context.repo.owner}/${github.context.repo.repo}/commits/${prNode.node.potentialMergeCommit.oid}`
-          )
-          .reply(200, makeCommitPage(changes[0]))
-
-        const octokit = github.getOctokit('justafaketoken')
-        const changed = await checkPullRequestForMergeChanges(octokit, github.context, prNode.node)
-
-        expect(changed).toBe(true)
-      })
-
-      it('returns yes when a sha is different', async () => {
-        const scope = nock('https://api.github.com', {
-          reqheaders: {
-            authorization: 'token justafaketoken'
-          }
-        })
-          .get(
-            `/repos/${github.context.repo.owner}/${github.context.repo.repo}/pulls/${prNode.node.number}/files?per_page=300`
-          )
-          .reply(200, [changes[0]])
-          .get(
-            `/repos/${github.context.repo.owner}/${github.context.repo.repo}/commits/${prNode.node.potentialMergeCommit.oid}`
-          )
-          .reply(200, makeCommitPage(changes[1]))
-
-        const octokit = github.getOctokit('justafaketoken')
-        const changed = await checkPullRequestForMergeChanges(octokit, github.context, prNode.node)
-
-        expect(changed).toBe(true)
-      })
-
-      it('returns no when everythign matches', async () => {
-        const scope = nock('https://api.github.com', {
-          reqheaders: {
-            authorization: 'token justafaketoken'
-          }
-        })
-          .get(
-            `/repos/${github.context.repo.owner}/${github.context.repo.repo}/pulls/${prNode.node.number}/files?per_page=300`
-          )
-          .reply(200, changes)
-          .get(
-            `/repos/${github.context.repo.owner}/${github.context.repo.repo}/commits/${prNode.node.potentialMergeCommit.oid}`
-          )
-          .reply(200, makeCommitPage(...changes))
-
-        const octokit = github.getOctokit('justafaketoken')
-        const changed = await checkPullRequestForMergeChanges(octokit, github.context, prNode.node)
-
-        expect(changed).toBe(false)
-      })
-    })
-  })
-
   describe('correctly determines labeling', () => {
     const expectedLabel: IGitHubLabelNode = {node: {id: 'MDU6TGFiZWwyNzYwMjE1ODI0', name: 'expected_label'}}
-    const makePr = (mergeable: string, ...label: IGitHubLabelNode[]): IGitHubPullRequest => {
+    const makePr = (mergeable: MergeableState, mergeStateStatus: MergeStateStatus, ...label: IGitHubLabelNode[]): IGitHubPullRequest => {
       return {
         id: 'MDExOlB1bGxSZXF1ZXN0NTc4ODgyNDUw',
         number: 7,
         mergeable: mergeable,
-        potentialMergeCommit: {
-          oid: '5ed0e15d4ca4ce73e847ee1f0369ee85a6e67bc9'
-        },
+        mergeStateStatus: mergeStateStatus,
         labels: {edges: [...label]}
       }
     }
@@ -1118,9 +813,9 @@ describe('queries', () => {
           )
           .reply(200, {data: {clientMutationId: 'auniqueid'}})
 
-        const pullRequest = makePr('CONFLICTING')
+        const pullRequest = makePr(MergeableState.CONFLICTING, MergeStateStatus.DIRTY)
         const octokit = github.getOctokit('justafaketoken')
-        const added = updatePullRequestConflictLabel(octokit, github.context, pullRequest, expectedLabel, false)
+        const added = updatePullRequestConflictLabel(octokit, pullRequest, expectedLabel, false)
 
         await expect(added).resolves.toBe(undefined)
       })
@@ -1140,19 +835,19 @@ describe('queries', () => {
             documentation_url: 'https://docs.github.com/graphql'
           })
 
-        const pullRequest = makePr('CONFLICTING')
+        const pullRequest = makePr(MergeableState.CONFLICTING, MergeStateStatus.DIRTY)
         const octokit = github.getOctokit('justafaketoken')
-        const added = updatePullRequestConflictLabel(octokit, github.context, pullRequest, expectedLabel, false)
+        const added = updatePullRequestConflictLabel(octokit, pullRequest, expectedLabel, false)
 
         await expect(added).rejects.toThrowError()
       })
 
       it('does nothing when already labeled', async () => {
-        const pullRequest = makePr('CONFLICTING', expectedLabel)
+        const pullRequest = makePr(MergeableState.CONFLICTING, MergeStateStatus.DIRTY, expectedLabel)
 
         const octokit = github.getOctokit('justafaketoken')
         const mockFunction = jest.spyOn(octokit, 'graphql').mockImplementation(jest.fn())
-        await updatePullRequestConflictLabel(octokit, github.context, pullRequest, expectedLabel, false)
+        await updatePullRequestConflictLabel(octokit, pullRequest, expectedLabel, false)
 
         expect(mockFunction).not.toBeCalled()
       })
@@ -1171,10 +866,10 @@ describe('queries', () => {
           )
           .reply(200, {data: {}})
 
-        const pullRequest = makePr('MERGEABLE', expectedLabel)
+        const pullRequest = makePr(MergeableState.MERGEABLE, MergeStateStatus.CLEAN, expectedLabel)
 
         const octokit = github.getOctokit('justafaketoken')
-        const removed = updatePullRequestConflictLabel(octokit, github.context, pullRequest, expectedLabel, false)
+        const removed = updatePullRequestConflictLabel(octokit, pullRequest, expectedLabel, false)
 
         await expect(removed).resolves.toBe(undefined)
       })
@@ -1191,206 +886,23 @@ describe('queries', () => {
             documentation_url: 'https://docs.github.com/graphql'
           })
 
-        const pullRequest = makePr('MERGEABLE', expectedLabel)
+        const pullRequest = makePr(MergeableState.MERGEABLE, MergeStateStatus.CLEAN, expectedLabel)
         const octokit = github.getOctokit('justafaketoken')
-        const removed = updatePullRequestConflictLabel(octokit, github.context, pullRequest, expectedLabel, false)
+        const removed = updatePullRequestConflictLabel(octokit, pullRequest, expectedLabel, false)
 
         await expect(removed).rejects.toThrowError()
       })
 
       it('does nothing when no label', async () => {
-        const pullRequest = makePr('MERGEABLE')
+        const pullRequest = makePr(MergeableState.MERGEABLE, MergeStateStatus.CLEAN)
 
         const octokit = github.getOctokit('justafaketoken')
         const mockFunction = jest.spyOn(octokit, 'graphql').mockImplementation(jest.fn())
-        await updatePullRequestConflictLabel(octokit, github.context, pullRequest, expectedLabel, false)
+        await updatePullRequestConflictLabel(octokit, pullRequest, expectedLabel, false)
 
         expect(mockFunction).not.toBeCalled()
       })
     })
-
-    describe('merge changes', () => {
-      it('removes an old label', async () => {
-        const pullRequest = makePr('MERGEABLE', expectedLabel)
-        const scope = nock('https://api.github.com', {
-          reqheaders: {
-            authorization: 'token justafaketoken'
-          }
-        })
-          .get(
-            `/repos/${github.context.repo.owner}/${github.context.repo.repo}/pulls/${pullRequest.number}/files?per_page=300`
-          )
-          .reply(200, [
-            {
-              sha: 'da207b42e77f336db8f7bad825daa71726ebf649',
-              filename: 'recipes/pango/all/conanfile.py',
-              status: 'modified',
-              patch:
-                '@@ -60,7 +60,7 @@ def requirements(self):\n             self.requires("freetype/2.10.4")\n \n         if self.options.with_fontconfi...'
-            }
-          ])
-          .get(
-            `/repos/${github.context.repo.owner}/${github.context.repo.repo}/commits/${pullRequest.potentialMergeCommit.oid}`
-          )
-          .reply(200, {
-            sha: '7ac057b641fec3b2b4a0ccdadb2b7476faca8bf0',
-            node_id: 'MDY6Q29tbWl0MjA0NjcxMjMyOjdhYzA1N2I2NDFmZWMzYjJiNGEwY2NkYWRiMmI3NDc2ZmFjYThiZjA=',
-            commit: {
-              author: {
-                name: 'SSE4',
-                email: 'tomskside@gmail.com',
-                date: '2021-03-14T00:37:50Z'
-              },
-              committer: {
-                name: 'GitHub',
-                email: 'noreply@github.com',
-                date: '2021-03-14T00:37:50Z'
-              },
-              message: 'Merge d66759bedaa040252d0ef66be5655202e324ff6c into c14910196b33ef8b99737078e284171a73418c17'
-            },
-            author: {
-              login: 'SSE4',
-              id: 870236,
-              node_id: 'MDQ6VXNlcjg3MDIzNg=='
-            },
-            committer: {
-              login: 'web-flow',
-              id: 19864447,
-              node_id: 'MDQ6VXNlcjE5ODY0NDQ3'
-            },
-            parents: [
-              {
-                sha: 'c14910196b33ef8b99737078e284171a73418c17'
-              },
-              {
-                sha: 'd66759bedaa040252d0ef66be5655202e324ff6c'
-              }
-            ],
-            files: [
-              {
-                sha: 'da207b42e77f336db8f7bad825daa71726ebf649',
-                filename: 'recipes/pango/all/conanfile.py',
-                status: 'modified',
-                patch:
-                  '@@ -60,7 +60,7 @@ def requirements(self):\n             self.requires("freetype/2.10.4")\n \n         if self.options.with_fontconf...'
-              }
-            ]
-          })
-          .post(
-            '/graphql',
-            /removeLabelsFromLabelable.*{labelIds: \[.*"MDU6TGFiZWwyNzYwMjE1ODI0.*\], labelableId: .*"MDExOlB1bGxSZXF1ZXN0NTc4ODgyNDUw.*"}/
-          )
-          .reply(200, {data: {}})
-
-        const octokit = github.getOctokit('justafaketoken')
-        const removed = updatePullRequestConflictLabel(octokit, github.context, pullRequest, expectedLabel, true)
-
-        await expect(removed).resolves.toBe(undefined)
-      })
-
-      it('removes an old label', async () => {
-        const pullRequest = makePr('MERGEABLE', expectedLabel)
-        const scope = nock('https://api.github.com', {
-          reqheaders: {
-            authorization: 'token justafaketoken'
-          }
-        })
-          .get(
-            `/repos/${github.context.repo.owner}/${github.context.repo.repo}/pulls/${pullRequest.number}/files?per_page=300`
-          )
-          .reply(200, [
-            {
-              sha: 'e1dde8f65c711ea3bd2a66557650a3606bf37c7f',
-              filename: 'recipes/libwebp/all/conandata.yml',
-              status: 'modified',
-              patch:
-                '@@ -5,6 +5,9 @@ sources:\n   "1.1.0":\n     url: "https://github.com/webmproject/libwebp/archive/v1.1.0.ta...'
-            },
-            {
-              sha: '6c1a86ff50796a44a635a5267ae7322f1c3252d6',
-              filename: 'recipes/libwebp/config.yml',
-              status: 'modified',
-              patch:
-                '@@ -3,3 +3,5 @@ versions:\n     folder: all\n   "1.1.0":\n     folder: all\n+  "1.2.0":\n+    folder: all'
-            }
-          ])
-          .get(
-            `/repos/${github.context.repo.owner}/${github.context.repo.repo}/commits/${pullRequest.potentialMergeCommit.oid}`
-          )
-          .reply(200, {
-            sha: 'd98404b1b9ebbc0397da93b81244511ab11867fe',
-            node_id: 'MDY6Q29tbWl0MjA0NjcxMjMyOmQ5ODQwNGIxYjllYmJjMDM5N2RhOTNiODEyNDQ1MTFhYjExODY3ZmU=',
-            commit: {
-              author: {
-                name: 'SpaceIm',
-                email: '30052553+SpaceIm@users.noreply.github.com',
-                date: '2021-03-13T20:07:06Z'
-              },
-              committer: {
-                name: 'GitHub',
-                email: 'noreply@github.com',
-                date: '2021-03-13T20:07:06Z'
-              },
-              message: 'Merge 4e3af1d3e958c8ad18c374d5254a52501980432d into c14910196b33ef8b99737078e284171a73418c17'
-            },
-            author: {
-              login: 'SpaceIm',
-              id: 30052553,
-              node_id: 'MDQ6VXNlcjMwMDUyNTUz'
-            },
-            committer: {
-              login: 'web-flow',
-              id: 19864447,
-              node_id: 'MDQ6VXNlcjE5ODY0NDQ3'
-            },
-            parents: [
-              {
-                sha: 'c14910196b33ef8b99737078e284171a73418c17'
-              },
-              {
-                sha: '4e3af1d3e958c8ad18c374d5254a52501980432d'
-              }
-            ],
-            files: [
-              {
-                sha: 'e1dde8f65c711ea3bd2a66557650a3606bf37c7f',
-                filename: 'recipes/libwebp/all/conandata.yml',
-                status: 'modified',
-                patch:
-                  '@@ -5,6 +5,9 @@ sources:\n   "1.1.0":\n     url: "https://github.com/webmproject/libwebp/archive/v1.1.0.ta...'
-              },
-              {
-                sha: '6c1a86ff50796a44b635a5267ae7322f1c3252d6',
-                filename: 'recipes/libwebp/config.yml',
-                status: 'modified',
-                patch:
-                  '@@ -3,3 +3,5 @@ versions:\n     folder: all\n   "1.1.0":\n     folder: all\n+  "1.2.0":\n+    folder: all'
-              }
-            ]
-          })
-          .post(
-            '/graphql',
-            /addLabelsToLabelable.*{labelIds: \[.*"MDU6TGFiZWwyNzYwMjE1ODI0.*\], labelableId: .*"MDExOlB1bGxSZXF1ZXN0NTc4ODgyNDUw.*"}/
-          )
-          .reply(200, {data: {}})
-
-        const octokit = github.getOctokit('justafaketoken')
-        const add = updatePullRequestConflictLabel(octokit, github.context, pullRequest, expectedLabel, true)
-
-        await expect(add).resolves.toBe(undefined)
-      })
-    })
-
-    it('does nothing when mergeable is unknown', async () => {
-      const pullRequest = makePr('UNKNOWN')
-
-      const octokit = github.getOctokit('justafaketoken')
-      const mockFunction = jest.spyOn(octokit, 'graphql').mockImplementation(jest.fn())
-      await updatePullRequestConflictLabel(octokit, github.context, pullRequest, expectedLabel, false)
-
-      expect(mockFunction).not.toBeCalled()
-    })
-  })
 
   describe('the whole sequence', () => {
     test('push event works', async () => {
@@ -1415,10 +927,8 @@ describe('queries', () => {
                     node: {
                       id: 'MDExOlB1bGxSZXF1ZXN0NDQzNTg3NjI1',
                       number: 2109,
-                      mergeable: 'UNKNOWN',
-                      potentialMergeCommit: {
-                        oid: 'dbe715994ec0bd51813f9e2b3e250c3e6b7dcf30'
-                      },
+                      mergeable: MergeableState.UNKNOWN,
+                      mergeStateStatus: MergeStateStatus.UNKNOWN,
                       labels: {
                         edges: [
                           {
@@ -1435,10 +945,8 @@ describe('queries', () => {
                     node: {
                       id: 'MDExOlB1bGxSZXF1ZXN0NDYxODY4OTkz',
                       number: 2370,
-                      mergeable: 'MERGEABLE',
-                      potentialMergeCommit: {
-                        oid: 'cdb96fa3e8b19bb280fec137bd26a8144fdabeac'
-                      },
+                      mergeable: MergeableState.MERGEABLE,
+                      mergeStateStatus: MergeStateStatus.CLEAN,
                       labels: {
                         edges: [
                           {
@@ -1476,10 +984,8 @@ describe('queries', () => {
                     node: {
                       id: 'MDExOlB1bGxSZXF1ZXN0NDQzNTg3NjI1',
                       number: 2109,
-                      mergeable: 'CONFLICTING',
-                      potentialMergeCommit: {
-                        oid: 'dbe715994ec0bd51813f9e2b3e250c3e6b7dcf30'
-                      },
+                      mergeable: MergeableState.CONFLICTING,
+                      mergeStateStatus: MergeStateStatus.DIRTY,
                       labels: {
                         edges: [
                           {
@@ -1496,10 +1002,8 @@ describe('queries', () => {
                     node: {
                       id: 'MDExOlB1bGxSZXF1ZXN0NDYxODY4OTkz',
                       number: 2370,
-                      mergeable: 'MERGEABLE',
-                      potentialMergeCommit: {
-                        oid: 'cdb96fa3e8b19bb280fec137bd26a8144fdabeac'
-                      },
+                      mergeable: MergeableState.MERGEABLE,
+                      mergeStateStatus: MergeStateStatus.CLEAN,
                       labels: {
                         edges: [
                           {
@@ -1567,10 +1071,8 @@ describe('queries', () => {
               pullRequest: {
                 id: 'MDExOlB1bGxSZXF1ZXN0NDQzNTg3NjI1',
                 number: mockPullRequestEvent.number,
-                mergeable: 'UNKNOWN',
-                potentialMergeCommit: {
-                  oid: 'dbe715994ec0bd51813f9e2b3e250c3e6b7dcf30'
-                },
+                mergeable: MergeableState.UNKNOWN,
+                mergeStateStatus: MergeStateStatus.UNKNOWN,
                 labels: {
                   edges: [
                     {
@@ -1592,10 +1094,8 @@ describe('queries', () => {
               pullRequest: {
                 id: 'MDExOlB1bGxSZXF1ZXN0NDQzNTg3NjI1',
                 number: mockPullRequestEvent.number,
-                mergeable: 'CONFLICTING',
-                potentialMergeCommit: {
-                  oid: 'dbe715994ec0bd51813f9e2b3e250c3e6b7dcf30'
-                },
+                mergeable: MergeableState.CONFLICTING,
+                mergeStateStatus: MergeStateStatus.DIRTY,
                 labels: {
                   edges: [
                     {
@@ -1649,4 +1149,5 @@ describe('queries', () => {
       expect(mock).toBeCalledWith('The label "this will not match" was not found in your repository!')
     })
   })
+})
 })

--- a/action.yml
+++ b/action.yml
@@ -19,7 +19,7 @@ inputs:
     description: "miliseconds between retries"
     required: false
     default: "5000"
-  detect_merge_changes:
+  mergeable_only:
     description: "treat soft changes within the merge commits as conflicts and label accordingly"
     required: false
     default: "false"

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -13,10 +13,21 @@ export interface IGitHubRepoLabels {
   }
 }
 
+export enum MergeStateStatus {
+  BEHIND,
+  BLOCKED,
+  CLEAN,
+  DIRTY,
+  DRAFT,
+  HAS_HOOKS,
+  UNKNOWN,
+  UNSTABLE
+}
+
 export interface IGitHubPullRequest {
   id: string
   number: number
-  mergeable: string
+  mergeStateStatus: MergeStateStatus
   potentialMergeCommit: {
     oid: string
   }

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -24,13 +24,17 @@ export enum MergeStateStatus {
   UNSTABLE
 }
 
+export enum MergeableState {
+  CONFLICTING,
+  MERGEABLE,
+  UNKNOWN
+}
+
 export interface IGitHubPullRequest {
   id: string
   number: number
+  mergeable: MergeableState
   mergeStateStatus: MergeStateStatus
-  potentialMergeCommit: {
-    oid: string
-  }
   labels: {
     edges: IGitHubLabelNode[]
   }
@@ -58,9 +62,4 @@ export interface IGitHubRepoPullRequests {
       pageInfo: IGitHubPageInfo
     }
   }
-}
-
-export interface IGitHubFileChange {
-  sha: string
-  filename: string
 }

--- a/src/label.ts
+++ b/src/label.ts
@@ -2,8 +2,7 @@ import * as core from '@actions/core'
 import {Context} from '@actions/github/lib/context'
 import {GitHub} from '@actions/github/lib/utils'
 
-import {IGitHubPullRequest, IGitHubLabelNode} from './interfaces'
-import {checkPullRequestForMergeChanges} from './pulls'
+import {IGitHubPullRequest, IGitHubLabelNode, MergeStateStatus} from './interfaces'
 import {addLabelToLabelable, removeLabelFromLabelable} from './queries'
 import {isAlreadyLabeled} from './util'
 
@@ -29,7 +28,6 @@ async function applyLabelable(
 
 export async function updatePullRequestConflictLabel(
   octokit: InstanceType<typeof GitHub>,
-  context: Context,
   pullRequest: IGitHubPullRequest,
   conflictLabel: IGitHubLabelNode,
   detectMergeChanges: boolean
@@ -37,24 +35,18 @@ export async function updatePullRequestConflictLabel(
   const hasLabel = isAlreadyLabeled(pullRequest, conflictLabel)
   const labelable: Labelable = {labelId: conflictLabel.node.id, labelableId: pullRequest.id}
 
-  switch (pullRequest.mergeable) {
-    case 'CONFLICTING':
+  if (pullRequest.mergeStateStatus) {
+    if (pullRequest.mergeStateStatus === MergeStateStatus.DIRTY) {
       await applyLabelable(octokit, labelable, hasLabel, pullRequest.number)
-      break
-
-    case 'MERGEABLE':
-      if (detectMergeChanges && (await checkPullRequestForMergeChanges(octokit, context, pullRequest))) {
+    } else {
+      if (detectMergeChanges && pullRequest.mergeStateStatus !== MergeStateStatus.CLEAN) {
         await applyLabelable(octokit, labelable, hasLabel, pullRequest.number)
-        break
       }
 
       if (hasLabel) {
         core.info(`Unmarking #${pullRequest.number}...`)
         await removeLabelFromLabelable(octokit, labelable)
       }
-      break
-
-    default:
-      break
+    }
   }
 }

--- a/src/label.ts
+++ b/src/label.ts
@@ -35,10 +35,20 @@ export async function updatePullRequestConflictLabel(
   const labelable: Labelable = {labelId: conflictLabel.node.id, labelableId: pullRequest.id}
 
   if (pullRequest.mergeStateStatus) {
+    if (
+      pullRequest.mergeable === MergeableState.MERGEABLE &&
+      pullRequest.mergeStateStatus === MergeStateStatus.CLEAN &&
+      hasLabel
+    ) {
+      core.info(`Unmarking #${pullRequest.number}...`)
+      await removeLabelFromLabelable(octokit, labelable)
+      return
+    }
+
     if (pullRequest.mergeStateStatus === MergeStateStatus.DIRTY) {
       await applyLabelable(octokit, labelable, hasLabel, pullRequest.number)
     } else {
-      if (mergeable_only && pullRequest.mergeable !== MergeableState.MERGEABLE) {
+      if (mergeable_only && pullRequest.mergeable !== MergeableState.MERGEABLE && !hasLabel) {
         await applyLabelable(octokit, labelable, hasLabel, pullRequest.number)
       } else if (hasLabel) {
         core.info(`Unmarking #${pullRequest.number}...`)

--- a/src/queries.ts
+++ b/src/queries.ts
@@ -4,7 +4,6 @@ import {
   IGitHubPRNode,
   IGitHubRepoLabels,
   IGitHubRepoPullRequests,
-  IGitHubFileChange,
   IGitHubRepoPullRequest,
   IGitHubPullRequest
 } from './interfaces'
@@ -22,10 +21,8 @@ const getPullRequestPages = async (
           node {
             id
             number
+            mergeable
             mergeStateStatus
-            potentialMergeCommit {
-              oid 
-            }
             labels(first: 100) {
               edges {
                 node {
@@ -79,10 +76,8 @@ export const getPullRequest = async (
       pullRequest(number: $number) {
         id
         number
+        mergeable
         mergeStateStatus
-        potentialMergeCommit {
-          oid
-        }
         labels(first: 100) {
           edges {
             node {

--- a/src/run.ts
+++ b/src/run.ts
@@ -53,7 +53,7 @@ export async function runOnPullRequest(
   core.endGroup()
 
   core.startGroup('🏷️ Updating labels')
-  await updatePullRequestConflictLabel(octokit, context, pr, conflictLabel, detectMergeChanges)
+  await updatePullRequestConflictLabel(octokit, pr, conflictLabel, detectMergeChanges)
   core.endGroup()
 }
 
@@ -71,7 +71,7 @@ export async function runOnAll(
 
   core.startGroup('🏷️ Updating labels')
   for (const pullRequest of pullRequests) {
-    await updatePullRequestConflictLabel(octokit, context, pullRequest.node, conflictLabel, detectMergeChanges)
+    await updatePullRequestConflictLabel(octokit, pullRequest.node, conflictLabel, detectMergeChanges)
   }
   core.endGroup()
 }

--- a/src/run.ts
+++ b/src/run.ts
@@ -20,8 +20,8 @@ export async function run(): Promise<void> {
     const waitMs = parseInt(core.getInput('wait_ms'), 10)
     core.debug(`maxRetries=${maxRetries}; waitMs=${waitMs}`)
 
-    const detectMergeChanges = core.getInput('detect_merge_changes') === 'true'
-    core.debug(`detectMergeChanges=${detectMergeChanges}`)
+    const mergeable_only = core.getInput('mergeable_only') === 'true'
+    core.debug(`mergeable_only=${mergeable_only}`)
 
     // Get the label to use
     const conflictLabel = findLabelByName(
@@ -30,10 +30,10 @@ export async function run(): Promise<void> {
     )
 
     if (github.context.eventName === 'pull_request') {
-      return await runOnPullRequest(octokit, github.context, conflictLabel, waitMs, maxRetries, detectMergeChanges)
+      return await runOnPullRequest(octokit, github.context, conflictLabel, waitMs, maxRetries, mergeable_only)
     }
 
-    await runOnAll(octokit, github.context, conflictLabel, waitMs, maxRetries, detectMergeChanges)
+    await runOnAll(octokit, github.context, conflictLabel, waitMs, maxRetries, mergeable_only)
   } catch (error) {
     core.setFailed(error.message)
   }
@@ -45,7 +45,7 @@ export async function runOnPullRequest(
   conflictLabel: IGitHubLabelNode,
   waitMs: number,
   maxRetries: number,
-  detectMergeChanges: boolean
+  mergeable_only: boolean
 ): Promise<void> {
   const prEvent = context.payload as PullRequestEvent
   core.startGroup(`🔎 Gather data for Pull Request #${prEvent.number}`)
@@ -53,7 +53,7 @@ export async function runOnPullRequest(
   core.endGroup()
 
   core.startGroup('🏷️ Updating labels')
-  await updatePullRequestConflictLabel(octokit, pr, conflictLabel, detectMergeChanges)
+  await updatePullRequestConflictLabel(octokit, pr, conflictLabel, mergeable_only)
   core.endGroup()
 }
 
@@ -63,7 +63,7 @@ export async function runOnAll(
   conflictLabel: IGitHubLabelNode,
   waitMs: number,
   maxRetries: number,
-  detectMergeChanges: boolean
+  mergeable_only: boolean
 ): Promise<void> {
   core.startGroup('🔎 Gather data for all Pull Requests')
   const pullRequests = await gatherPullRequests(octokit, context, waitMs, maxRetries)
@@ -71,7 +71,7 @@ export async function runOnAll(
 
   core.startGroup('🏷️ Updating labels')
   for (const pullRequest of pullRequests) {
-    await updatePullRequestConflictLabel(octokit, pullRequest.node, conflictLabel, detectMergeChanges)
+    await updatePullRequestConflictLabel(octokit, pullRequest.node, conflictLabel, mergeable_only)
   }
   core.endGroup()
 }

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,8 +1,8 @@
-import {IGitHubPRNode, IGitHubPullRequest, IGitHubLabelNode, IGitHubRepoLabels} from './interfaces'
+import {IGitHubPRNode, IGitHubPullRequest, IGitHubLabelNode, IGitHubRepoLabels, MergeStateStatus} from './interfaces'
 
 export function getPullrequestsWithoutMergeStatus(pullrequests: IGitHubPRNode[]): IGitHubPRNode[] {
   return pullrequests.filter((pullrequest: IGitHubPRNode) => {
-    return pullrequest.node.mergeable === 'UNKNOWN'
+    return pullrequest.node.mergeStateStatus === MergeStateStatus.UNKNOWN
   })
 }
 


### PR DESCRIPTION
Feature picked from https://github.com/mschilde/auto-label-merge-conflicts/pull/46

Also:
* Enourmously simplified the file diff schema by using GitHub's own API response.
* Cleaned the code a bit by using enums.


I need some help in making the tests pass though, I can't fugure out why they're failing :)