### PR TITLE
Update runtime to NodeJS 16

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -27,5 +27,5 @@ inputs:
     description: "the comment to leave on a pull request when adding the conflict label"
     required: false
 runs:
-  using: "node12"
+  using: "node16"
   main: "dist/index.js"


### PR DESCRIPTION
which is now the default for GitHub Actions https://github.blog/changelog/2021-12-10-github-actions-github-hosted-runners-now-run-node-js-16-by-default/